### PR TITLE
fixed repetitive loading in word feed

### DIFF
--- a/frontend/src/components/WordCard.tsx
+++ b/frontend/src/components/WordCard.tsx
@@ -1,35 +1,38 @@
 import { getColorForDifficulty } from "@/lib/getWordColors";
 import { useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
-import { useCallback } from "react";
+import { useCallback, forwardRef } from "react";
 
-interface WordCardProps {
-    word: string;
-    difficulty: number;
-    _id: string;
+interface WordCardProps extends React.InputHTMLAttributes<HTMLDivElement> {
+  word: string;
+  difficulty: number;
+  _id: string;
 }
 
-function WordCard({ word, difficulty, _id }: WordCardProps) {
+const WordCard = forwardRef<HTMLDivElement, WordCardProps>(
+  ({ word, difficulty, _id, ...props }, ref) => {
     const customWordColor = getColorForDifficulty(difficulty);
     const navigate = useNavigate();
 
     const handleClick = useCallback(() => {
-        navigate(`/meaning/${word}`);
+      navigate(`/meaning/${word}`);
     }, [navigate, word]);
 
     return (
-        <div
-            key={_id}
-            onClick={handleClick}
-            className="transition-transform hover:scale-105 w-fit p-2"
-            style={{
-                fontSize: `${difficulty * 5 + 1}em`,
-                color: customWordColor,
-            }}
-        >
-            {word}
-        </div>
+      <div
+        key={_id}
+        ref={ref}
+        onClick={handleClick}
+        className="transition-transform hover:scale-105 w-fit p-2"
+        style={{
+          fontSize: `${difficulty * 5 + 1}em`,
+          color: customWordColor,
+        }}
+        {...props}
+      >
+        {word}
+      </div>
     );
-}
+  }
+);
 
 export default WordCard;

--- a/frontend/src/components/WordFeed.tsx
+++ b/frontend/src/components/WordFeed.tsx
@@ -1,77 +1,68 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useCallback, useRef } from "react";
 import { loadWords } from "@/lib/loadWords";
 import WordCard from "./WordCard";
-import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface WordInterface {
-    _id: string;
-    word: string;
-    meaning: string;
-    difficulty: number;
-    __v: number;
+  _id: string;
+  word: string;
+  meaning: string;
+  difficulty: number;
+  __v: number;
 }
 
 export default function WordFeed({ lastCount }: { lastCount: number }) {
-    const divRef = useRef<HTMLDivElement>(null);
-    const sentinelRef = useRef<HTMLDivElement | null>(null);
-    const [downRanOnce, setDownRanOnce] = useState(false);
-    const [hasMoreDown, setHasMoreDown] = useState(true);
-    const [pages, setPages] = useState<WordInterface[]>([]);
-    const [isLoading, setIsLoading] = useState(false);
-    const [count, setCount] = useState(lastCount);
-    const limit = 3;
-    const bookId = "6798d8fcd21a1a2ab5cab6b2";
+  const [count, setCount] = useState(lastCount);
+  //hardcoded for now, will come in as a param in future
+  const limit = 3;
+  const bookId = "6798d8fcd21a1a2ab5cab6b2";
 
-    const next = async () => {
-        try {
-            setIsLoading(true);
-            setCount((prev) => prev + 1);
-            const response = await loadWords(bookId, count, limit);
-            const newData = response.data.pages.flatMap((page: any) => page.words);
-            setPages((prev) => [...prev, ...newData]);
-            setHasMoreDown(newData.length > 0);
-            setDownRanOnce(true);
-        } finally {
-            setIsLoading(false);
-        }
-    };
+  const { loading, error, words, hasMore } = loadWords(
+    bookId,
+    count,
+    limit
+  );
+  const observer = useRef<IntersectionObserver | null>(null);
 
-    useEffect(() => {
-        next();
-    }, []);
+  const lastWordElementRef = useCallback((node: HTMLDivElement) => {
+    if (loading) return;
+    // Disconnect existing observer before creating a new one
+    if (observer.current) {
+      observer.current.disconnect();
+    }
+    observer.current = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore) {
+        setCount((prevCount) => prevCount + 1);
+      }
+    });
+    if (node) {
+      observer.current.observe(node);
+    }
+    console.log(node);
+  }, [loading, hasMore]);
+  
 
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            (entries) => {
-                if (entries[0].isIntersecting && hasMoreDown && !isLoading) {
-                    next();
-                }
-            },
-            { root: divRef.current, threshold: 0.1 }
-        );
+  return (
+    <div className="h-[500px] overflow-y-auto flex flex-wrap justify-center items-center w-[90%] mx-auto text-center gap-[10px] relative p-4">
+      {error&& <div>error occured while fetching data</div>}
+      {!error && words.map((word, index) => {
+        if (words.length == index + 1)
+          return (
+            <WordCard ref={lastWordElementRef} word={word.word} difficulty={word.difficulty} _id={word._id} />
+          );
+        else return <WordCard word={word.word} difficulty={word.difficulty} _id={word._id} />
+      })}
 
-        if (sentinelRef.current) observer.observe(sentinelRef.current);
-
-        return () => {
-            if (sentinelRef.current) observer.unobserve(sentinelRef.current);
-        };
-    }, [hasMoreDown, isLoading]);
-
-    return (
-        <div
-            ref={divRef}
-            className="h-[500px] overflow-y-auto flex flex-wrap justify-center items-center w-[90%] mx-auto text-center gap-[10px] relative p-4"
-        >
-            {pages.map((word) => (
-                <WordCard word={word.word} difficulty={word.difficulty} _id={word._id} />
-            ))}
-
-            {isLoading && (
-                <Skeleton className="w-full h-10 rounded-md my-2" />
-            )}
-
-            <div ref={sentinelRef} className="h-px w-full" />
+      {!error && loading && (
+        <div>
+          <Skeleton className="w-full h-10 rounded-md my-2" />
+          <Skeleton className="w-full h-10 rounded-md my-2" />
+          <Skeleton className="w-full h-10 rounded-md my-2" />
+          <Skeleton className="w-full h-10 rounded-md my-2" />
+          <Skeleton className="w-full h-10 rounded-md my-2" />
+          <Skeleton className="w-full h-10 rounded-md my-2" />
         </div>
-    );
+      )}
+    </div>
+  );
 }

--- a/frontend/src/lib/loadWords.ts
+++ b/frontend/src/lib/loadWords.ts
@@ -1,11 +1,49 @@
 import axios from "axios";
+import { Canceler } from "axios";
+import { useEffect, useState } from "react";
 
-function loadWords(bookId:string,lastCount:number,limit:number){
-    console.log("-------------->"+lastCount+"     "+limit);
-    const reqObject=axios.get(`http://localhost:5000/api/v1/book/pages?bookId=${bookId}&page=${lastCount}&limit=${limit}`,{
-        withCredentials: true,
-      });
-    return reqObject;
+interface WordInterface {
+    _id: string;
+    word: string;
+    meaning: string;
+    difficulty: number;
+    __v: number;
 }
 
-export {loadWords};
+function loadWords(bookId: string, count: number, limit: number) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [words, setWords] = useState<WordInterface[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  console.log("-------------->" + count + "     " + limit);
+
+  useEffect(()=>{
+    setLoading(true);
+    setError(false);
+
+    let cancel:Canceler
+    axios({
+        method:"GET",
+        url:`http://localhost:5000/api/v1/book/pages?bookId=${bookId}&page=${count}&limit=${limit}`,
+        withCredentials: true,
+        cancelToken:new axios.CancelToken(c=>cancel=c)
+    }).then(res=>{
+      const newWords=res.data.pages.flatMap((page: any) => page.words);
+      setWords(words=>{
+            return [...words,...newWords]
+        })
+        setHasMore(res.data.pages.length>0)
+        setLoading(false)
+        console.log(res.data)
+    }).catch((e)=>{
+        if(axios.isCancel(e))return;
+        setError(true);
+        console.log(e);
+    })
+
+    return ()=>cancel();
+},[bookId,count,limit])
+return {loading,error,words,hasMore};
+}
+
+export { loadWords };


### PR DESCRIPTION
# Existing problem
1. The `WordFeed `is buggy
2. When the user reaches the end of the feed it sometimes loads content until there is no more content to load

# Solution
1. Segregated the call for the `HTTP request` and handling into a **separate custom hook**
2. Used `useRef `from React to track the position of last word in the word feed
3. Used `useCallback `and `observer `to fetch more data when last word in feed becomes visible

# Result 
1. The word feed only makes a **single request** to load more data, when the user reaches the end